### PR TITLE
Enable access to non-public elements of java.lang

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,9 @@
     <easymockVersion>4.3</easymockVersion>
     <compilerPluginVersion>3.8.1</compilerPluginVersion>
     <surefireVersion>3.0.0-M5</surefireVersion>
+    <argLine>
+      --add-opens java.base/java.lang=ALL-UNNAMED
+    </argLine>
   </properties>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -83,9 +83,6 @@
     <easymockVersion>4.3</easymockVersion>
     <compilerPluginVersion>3.8.1</compilerPluginVersion>
     <surefireVersion>3.0.0-M5</surefireVersion>
-    <argLine>
-      --add-opens java.base/java.lang=ALL-UNNAMED
-    </argLine>
   </properties>
   <dependencies>
     <dependency>
@@ -135,6 +132,12 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${surefireVersion}</version>
+        <!-- TODO: remove once easymock is updated. See: https://github.com/easymock/easymock/issues/274 -->
+        <configuration>
+          <argLine>
+            --add-opens java.base/java.lang=ALL-UNNAMED
+          </argLine>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
This should fix `xmvn-connector-ivy` for builds with JDK17.